### PR TITLE
Update USB vid pid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Build web app
-        run: flutter build web --release --base-href /
+        run: flutter build web --release --dart-define=BUILD_NUMBER=${{ github.run_number }} --base-href /
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "picotracker_client",
+            "request": "launch",
+            "type": "dart",
+            "args": [
+                "--dart-define",
+                "BUILD_NUMBER=42"
+            ]
+        },
+        {
+            "name": "picotracker_client (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "picotracker_client (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -12,9 +12,7 @@ import 'pico_app.dart';
 import 'widgets/pico_screen.dart';
 
 class MainScreen extends StatefulWidget {
-  const MainScreen({super.key, required this.title});
-
-  final String title;
+  const MainScreen({super.key});
 
   @override
   State<MainScreen> createState() => _MainScreenState();
@@ -66,7 +64,6 @@ class _MainScreenState extends State<MainScreen> {
 
   @override
   Widget build(BuildContext context) {
-    print("connected: ${serialHandler.isConnected}");
     return Scaffold(
         backgroundColor: Colors.black,
         body: Stack(
@@ -74,6 +71,7 @@ class _MainScreenState extends State<MainScreen> {
             PicoScreen(
               _grid,
               _grid.background,
+              connected: serialHandler.isConnected(),
             ),
             Visibility(
               visible: !serialHandler.isConnected(),

--- a/lib/pico_app.dart
+++ b/lib/pico_app.dart
@@ -20,13 +20,12 @@ class PicoApp extends StatelessWidget {
     return ListenableBuilder(
       builder: (BuildContext context, Widget? child) {
         return MaterialApp(
-          title: 'picoTracker',
           theme: ThemeData(
             colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
             useMaterial3: true,
             fontFamily: fontNotifier.value.name,
           ),
-          home: const MainScreen(title: 'picoTracker'),
+          home: const MainScreen(),
         );
       },
       listenable: fontNotifier,

--- a/lib/serialport_native.dart
+++ b/lib/serialport_native.dart
@@ -17,7 +17,7 @@ class SerialPortHandler {
   SerialPortHandler(this.cmdBuilder);
 
   void chooseSerialDevice() async {
-    //TODO, for now just use hardcoded port
+    // for now just use hardcoded port
     try {
       SerialPort(portname).close();
       _initPort();

--- a/lib/serialport_web.dart
+++ b/lib/serialport_web.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'package:flutter/foundation.dart';
 import 'package:webserial/webserial.dart';
 import 'dart:js_interop';

--- a/lib/serialport_web.dart
+++ b/lib/serialport_web.dart
@@ -4,6 +4,9 @@ import 'dart:js_interop';
 
 import 'command_builder.dart';
 
+const PICOTRACKER_VENDOR_ID = 0x2E8A;
+const PICOTRACKER_PRODUCT_ID = 0x0003;
+
 class SerialPortHandler {
   final CmdBuilder cmdBuilder;
   JSSerialPort? port;
@@ -16,7 +19,10 @@ class SerialPortHandler {
     try {
       // Create filter options for specific vendor ID
       final filters = [
-        JSFilterObject(usbVendorId: 0xcafe, usbProductId: 0x4009)
+        JSFilterObject(
+          usbVendorId: PICOTRACKER_VENDOR_ID,
+          usbProductId: PICOTRACKER_PRODUCT_ID,
+        )
       ];
 
       port = await requestWebSerialPort(filters.toJS);

--- a/lib/widgets/pico_screen.dart
+++ b/lib/widgets/pico_screen.dart
@@ -10,20 +10,27 @@ final KEY_RIGHT = int.parse("100", radix: 2);
 final KEY_UP = int.parse("1000", radix: 2);
 final KEY_L = int.parse("10000", radix: 2);
 
+const buildVersion = String.fromEnvironment('BUILD_NUMBER');
+
 class PicoScreen extends StatelessWidget {
   final ScreenCharGrid grid;
   final Color backgroundColor;
+  final bool connected;
 
-  const PicoScreen(this.grid, this.backgroundColor, {super.key});
+  const PicoScreen(this.grid, this.backgroundColor,
+      {super.key, required this.connected});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.all(4.0),
-          child: Text("picoTracker",
-              style: Theme.of(context).textTheme.headlineLarge),
+        Visibility(
+          visible: !connected,
+          child: Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: Text("picoTracker Client  [build $buildVersion]",
+                style: Theme.of(context).textTheme.headlineSmall),
+          ),
         ),
         SizedBox(
           height: 754,


### PR DESCRIPTION
The pT firmware will now use just [the standard RPI RP2040 USB VID/PID](https://github.com/xiphonics/picoTracker/issues/281).

This PR updates the filter to match the new VIS/PID. This PR also updates the UI to display the webapp clients build number and adds the number to the app via a dart env var when building on Github actions CI.